### PR TITLE
[FEAT] 이메일 알림 기능 및 이메일 수신 동의 API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testImplementation 'org.springframework.batch:spring-batch-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'io.rest-assured:rest-assured'
 
 	// AWS S3
 	implementation platform('software.amazon.awssdk:bom:2.20.56')

--- a/src/main/java/com/server/moabook/MoabookApplication.java
+++ b/src/main/java/com/server/moabook/MoabookApplication.java
@@ -2,7 +2,9 @@ package com.server.moabook;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class MoabookApplication {
 

--- a/src/main/java/com/server/moabook/config/MailConfig.java
+++ b/src/main/java/com/server/moabook/config/MailConfig.java
@@ -1,0 +1,16 @@
+package com.server.moabook.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        return new JavaMailSenderImpl();
+    }
+}

--- a/src/main/java/com/server/moabook/config/MailConfig.java
+++ b/src/main/java/com/server/moabook/config/MailConfig.java
@@ -1,16 +1,55 @@
 package com.server.moabook.config;
 
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
+import java.util.Properties;
+
 @Configuration
 public class MailConfig {
 
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.debug}")
+    private boolean debug;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttls;
+
     @Bean
     public JavaMailSender javaMailSender() {
-        return new JavaMailSenderImpl();
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties properties = mailSender.getJavaMailProperties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttls);
+        properties.put("mail.smtp.debug", debug);
+
+        mailSender.setJavaMailProperties(properties);
+        mailSender.setDefaultEncoding("UTF-8");
+
+        return mailSender;
     }
 }

--- a/src/main/java/com/server/moabook/config/SchedulerConfig.java
+++ b/src/main/java/com/server/moabook/config/SchedulerConfig.java
@@ -1,0 +1,21 @@
+package com.server.moabook.config;
+
+import com.server.moabook.mail.BatchService;
+import com.server.moabook.mail.MailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SchedulerConfig {
+
+    private final BatchService batchService;
+
+    @Scheduled(fixedDelay = 3600000, initialDelay = 5000)
+    public void run() {
+        batchService.sendMail();
+    }
+}

--- a/src/main/java/com/server/moabook/global/exception/message/ErrorMessage.java
+++ b/src/main/java/com/server/moabook/global/exception/message/ErrorMessage.java
@@ -13,7 +13,8 @@ public enum ErrorMessage {
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 그룹을 찾을 수 없습니다."),
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 책을 찾을 수 없습니다."),
     PAGE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 책을 찾을 수 없습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다."),
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST.value(), "이메일 형식이 올바르지 않습니다."),;
     private final int code;
     private final String message;
 }

--- a/src/main/java/com/server/moabook/global/exception/message/SuccessMessage.java
+++ b/src/main/java/com/server/moabook/global/exception/message/SuccessMessage.java
@@ -23,7 +23,8 @@ public enum SuccessMessage {
     CREATE_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 생성을 성공하였습니다."),
     SAVE_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 저장을 성공하였습니다."),
     SELECT_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 조회를 성공하였습니다."),
-    DELETE_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 삭제를 성공하였습니다.");
+    DELETE_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 삭제를 성공하였습니다."),
+    UPDATE_RECEIVED_EMAIL_SUCCESS(HttpStatus.OK.value(), "이메일 수신 동의 여부가 반영되었습니다."),;
 
     private final int code;
     private final String message;

--- a/src/main/java/com/server/moabook/mail/BatchService.java
+++ b/src/main/java/com/server/moabook/mail/BatchService.java
@@ -1,0 +1,28 @@
+package com.server.moabook.mail;
+
+import com.server.moabook.oauth2.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BatchService {
+
+    private final UserRepository userRepository;
+    private final MailService mailService;
+
+    public void sendMail() {
+
+        LocalDateTime oneMonthAgoDateTime = LocalDateTime.now().minusMonths(1);
+        String[] userEmailList = userRepository.findAllByExpiredUsersEmail(oneMonthAgoDateTime).toArray(new String[0]);
+
+        mailService.sendSimpleMailMessage(userEmailList);
+    }
+}

--- a/src/main/java/com/server/moabook/mail/BatchService.java
+++ b/src/main/java/com/server/moabook/mail/BatchService.java
@@ -1,5 +1,6 @@
 package com.server.moabook.mail;
 
+import com.server.moabook.oauth2.entity.SocialUserEntity;
 import com.server.moabook.oauth2.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,10 @@ public class BatchService {
 
         LocalDateTime oneMonthAgoDateTime = LocalDateTime.now().minusMonths(1);
         String[] userEmailList = userRepository.findAllByExpiredUsersEmail(oneMonthAgoDateTime).toArray(new String[0]);
-
+        //이메일을 발송했다면 해당 사용자들의 sended_email을 true로 변경
+        for (String email : userEmailList) {
+            userRepository.findByEmail(email).ifPresent(SocialUserEntity::updateSendedEmailTrue);
+        }
         mailService.sendSimpleMailMessage(userEmailList);
     }
 }

--- a/src/main/java/com/server/moabook/mail/BatchService.java
+++ b/src/main/java/com/server/moabook/mail/BatchService.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/com/server/moabook/mail/MailService.java
+++ b/src/main/java/com/server/moabook/mail/MailService.java
@@ -1,0 +1,90 @@
+package com.server.moabook.mail;
+
+import com.server.moabook.oauth2.repository.UserRepository;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendSimpleMailMessage(String[] userEmails) {
+
+        SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+
+        try {
+            // 메일을 받을 수신자 설정
+            simpleMailMessage.setTo(userEmails);
+
+            // 메일의 제목 설정
+            simpleMailMessage.setSubject("[MoABook] 모아북에서 내가 저장한 내용을 정리하세요!");
+
+            // 메일의 내용 설정
+            simpleMailMessage.setText("모아북을 사용하신 지 벌써 한 달이 지났어요! 내가 저장한 내용을 정리하고, 새로운 계획을 세워보세요!");
+
+            javaMailSender.send(simpleMailMessage);
+
+            log.info("메일 발송 성공!");
+        } catch (Exception e) {
+            log.info("메일 발송 실패!");
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public void sendMimeMessage(String[] userEmails) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        try{
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+
+            // 메일을 받을 수신자 설정
+            mimeMessageHelper.setTo(userEmails);
+            // 메일의 제목 설정
+            mimeMessageHelper.setSubject("[MoABook] 모아북에서 내가 저장한 내용을 정리하세요!");
+
+            // html 문법 적용한 메일의 내용
+            String content = """
+                    <!DOCTYPE html>
+                    <html xmlns:th="http://www.thymeleaf.org">
+                                        
+                    <body>
+                    <div style="margin:100px;">
+                        <h1> 테스트 메일 </h1>
+                        <br>
+                                        
+                                        
+                        <div align="center" style="border:1px solid black;">
+                            <h3> 테스트 메일 내용 </h3>
+                        </div>
+                        <br/>
+                    </div>
+                                        
+                    </body>
+                    </html>
+                    """;
+
+            // 메일의 내용 설정
+            mimeMessageHelper.setText(content, true);
+
+            javaMailSender.send(mimeMessage);
+
+            log.info("메일 발송 성공!");
+        } catch (Exception e) {
+            log.info("메일 발송 실패!");
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/server/moabook/mail/MailService.java
+++ b/src/main/java/com/server/moabook/mail/MailService.java
@@ -5,6 +5,7 @@ import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -28,6 +29,11 @@ public class MailService {
             // 메일을 받을 수신자 설정
             simpleMailMessage.setTo(userEmails);
 
+            if (userEmails.length == 0) {
+                log.info("메일을 발송할 대상이 없습니다.");
+                return;
+            }
+
             // 메일의 제목 설정
             simpleMailMessage.setSubject("[MoABook] 모아북에서 내가 저장한 내용을 정리하세요!");
 
@@ -39,7 +45,7 @@ public class MailService {
             log.info("메일 발송 성공!");
         } catch (Exception e) {
             log.info("메일 발송 실패!");
-            throw new RuntimeException(e);
+            throw new MailSendException("메일 발송 실패!");
         }
 
     }

--- a/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -29,7 +30,12 @@ public class SocialUserEntity {
 
     private String profile_image_url;
 
+    private LocalDateTime updated_at;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Group> groups;
 
+    public void updateUserUpdateTime(){
+        this.updated_at = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
@@ -54,4 +54,8 @@ public class SocialUserEntity {
     public void updateSendedEmailFalse(){
         this.sended_email = false;
     }
+
+    public void updateEmail(String email){
+        this.email = email;
+    }
 }

--- a/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
@@ -43,8 +43,8 @@ public class SocialUserEntity {
         this.updated_at = LocalDateTime.now();
     }
 
-    public void updateReceivedEmail(){
-        this.received_email = true;
+    public void updateReceivedEmail(boolean check){
+        this.received_email = check;
     }
 
     public void updateSendedEmailTrue(){

--- a/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
@@ -32,10 +32,26 @@ public class SocialUserEntity {
 
     private LocalDateTime updated_at;
 
+    private Boolean received_email;
+
+    private Boolean sended_email;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Group> groups;
 
     public void updateUserUpdateTime(){
         this.updated_at = LocalDateTime.now();
+    }
+
+    public void updateReceivedEmail(){
+        this.received_email = true;
+    }
+
+    public void updateSendedEmailTrue(){
+        this.sended_email = true;
+    }
+
+    public void updateSendedEmailFalse(){
+        this.sended_email = false;
     }
 }

--- a/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
+++ b/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
@@ -2,6 +2,16 @@ package com.server.moabook.oauth2.repository;
 
 import com.server.moabook.oauth2.entity.SocialUserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<SocialUserEntity, Long> {
+    SocialUserEntity findByUsername(String username);
+    Optional<SocialUserEntity> findByEmail(String email);
+
+    @Query("SELECT u.email FROM SocialUserEntity u WHERE u.updated_at < :minusOneMonthAgoDateTime")
+    List<String> findAllByExpiredUsersEmail(LocalDateTime minusOneMonthAgoDateTime);
 }

--- a/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
+++ b/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
@@ -12,6 +12,6 @@ public interface UserRepository extends JpaRepository<SocialUserEntity, Long> {
     SocialUserEntity findByUsername(String username);
     Optional<SocialUserEntity> findByEmail(String email);
 
-    @Query("SELECT u.email FROM SocialUserEntity u WHERE u.updated_at < :minusOneMonthAgoDateTime")
+    @Query("SELECT u.email FROM SocialUserEntity u WHERE u.updated_at < :minusOneMonthAgoDateTime AND u.received_email = true AND u.sended_email = false")
     List<String> findAllByExpiredUsersEmail(LocalDateTime minusOneMonthAgoDateTime);
 }

--- a/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
+++ b/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
@@ -46,7 +46,10 @@ public class GeneralMemberService {
                     return userRepository.save(newGeneralMember);
                 });
 
+        //로그인 시 사용자 사용시간 업데이트
         socialUserEntity.updateUserUpdateTime();
+        //로그인 시 사용자가 나중에 다시 접속이 오래 이어지지 않았을 때 다시 이메일을 받을 수 있게 설정
+        socialUserEntity.updateSendedEmailFalse();
 
         // JWT 토큰 발급
         String jwtToken = jwtTokenProvider.issueAccessToken(

--- a/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
+++ b/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -29,7 +31,7 @@ public class GeneralMemberService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
-    // 사용자 정보 가져오기 - 이메일, 닉네임, 프로필 사진, 여행 등급
+    // 사용자 정보 가져오기 - 이메일, 닉네임, 프로필 사진
     public SuccessLoginResponseDto findUserWithReact(KakaoUserInfoRequestDto userInfo) {
 
         SocialUserEntity socialUserEntity = userRepository.findById(userInfo.id())
@@ -43,6 +45,8 @@ public class GeneralMemberService {
                             .build();
                     return userRepository.save(newGeneralMember);
                 });
+
+        socialUserEntity.updateUserUpdateTime();
 
         // JWT 토큰 발급
         String jwtToken = jwtTokenProvider.issueAccessToken(

--- a/src/main/java/com/server/moabook/user/controller/UserController.java
+++ b/src/main/java/com/server/moabook/user/controller/UserController.java
@@ -61,10 +61,12 @@ public class UserController {
     @PatchMapping
     public ResponseEntity<SuccessStatusResponse<Void>> updateReceivedEmail(
             @RequestHeader("Authorization") String token,
-            @RequestParam("received_email") boolean checkReceivedEmail) {
+            @RequestParam(value = "user_email", required = false) String email,
+            @RequestParam("is_received_email") boolean checkReceivedEmail) {
 
         Long userId = jwtTokenProvider.getUserFromJwt(token);
-        userService.updateReceivedEmail(userId, checkReceivedEmail);
+
+        userService.updateReceivedEmail(userId, email, checkReceivedEmail);
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessStatusResponse.of(

--- a/src/main/java/com/server/moabook/user/controller/UserController.java
+++ b/src/main/java/com/server/moabook/user/controller/UserController.java
@@ -58,4 +58,19 @@ public class UserController {
         );
     }
 
+    @PatchMapping
+    public ResponseEntity<SuccessStatusResponse<Void>> updateReceivedEmail(
+            @RequestHeader("Authorization") String token,
+            @RequestParam("received_email") boolean checkReceivedEmail) {
+
+        Long userId = jwtTokenProvider.getUserFromJwt(token);
+        userService.updateReceivedEmail(userId, checkReceivedEmail);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessStatusResponse.of(
+                        SuccessMessage.UPDATE_RECEIVED_EMAIL_SUCCESS, null
+                )
+        );
+    }
+
 }

--- a/src/main/java/com/server/moabook/user/service/UserService.java
+++ b/src/main/java/com/server/moabook/user/service/UserService.java
@@ -35,4 +35,10 @@ public class UserService {
         groupRepository.deleteAll(socialUserEntity.getGroups());
     }
 
+    public void updateReceivedEmail(Long userId, boolean check) {
+        SocialUserEntity socialUserEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException(String.valueOf(ErrorMessage.USER_NOT_FOUND)));
+        socialUserEntity.updateReceivedEmail(check);
+    }
+
 }

--- a/src/main/java/com/server/moabook/user/service/UserService.java
+++ b/src/main/java/com/server/moabook/user/service/UserService.java
@@ -9,6 +9,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.regex.Pattern;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -16,6 +18,10 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final GroupRepository groupRepository;
+
+    private static final String EMAIL_REGEX = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX);
+
 
     public SelectUserResponseDto select(Long userId) {
         SocialUserEntity socialUserEntity = userRepository.findById(userId)
@@ -35,10 +41,20 @@ public class UserService {
         groupRepository.deleteAll(socialUserEntity.getGroups());
     }
 
-    public void updateReceivedEmail(Long userId, boolean check) {
+    public void updateReceivedEmail(Long userId, String email, boolean check) {
         SocialUserEntity socialUserEntity = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalStateException(String.valueOf(ErrorMessage.USER_NOT_FOUND)));
         socialUserEntity.updateReceivedEmail(check);
+        if(isValidEmail(email)) {
+            socialUserEntity.updateEmail(email);
+        }
+    }
+
+    public static boolean isValidEmail(String email) {
+        if (email == null || email.trim().isEmpty()) {
+            return false; // null 또는 빈 값 체크
+        }
+        return EMAIL_PATTERN.matcher(email).matches();
     }
 
 }


### PR DESCRIPTION
# 이메일 알림
- 사용자가 로그인 한 지 한 달이 지나면 이메일로 알림을 전송하도록 설계했습니다. 

유저가 로그인할 때 이루어지는 동작은 다음과 같습니다.
1. 사용자가 사용한 시간이 업데이트
2. 이메일을 이미 받았는지 받지 않았는 지에 대한 여부 필드(sended_email)를 다시 false로 수정하여 추후에 다시 이메일을 받을 수 있도록 설정

또한, 이메일이 전송되는 조건은 다음과 같습니다. 

1. 이메일 수신 동의를 한 유저(received_email == true)
2. 이메일을 아직 받지 않은 유저 (sended_email == false)
3. 로그인이 시행된 시점으로부터 한 달이 지난 유저 

- Gmail을 사용하여 이메일이 전송되도록 했고, 원래는 html로 알림이 가면 좋은데, 이 부분은 민경님께 부탁드리거나 프론트분들과 협의해야 할 것 같습니다. 

![image](https://github.com/user-attachments/assets/c00561c0-c614-4799-b8a9-8a41feb83c8b)

![image](https://github.com/user-attachments/assets/f5dc0e86-399e-4ece-a33c-a2cd2af6ac58)

# 이메일 수신 동의 여부 확인 및 로그인 시 주의사항
이메일 수신 동의 여부를 추후에 수정할 수 있도록 PATCH API를 구현해두었습니다. 이 API에서는 사용자가 이메일 수신 동의 뷰에서 이메일 수신 동의를 위해 이메일, 알림 수신 여부를 체크하면 그 값들을 받아 업데이트합니다. 여기서, 이메일을 이미 입력한 사용자의 경우에는 이메일을 받지 않고 수신 여부만 수정할 수 있도록도 구현해두었습니다. 
