### PR TITLE
[REFACTOR] kakao 로그인 로직 수정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'io.jsonwebtoken:jjwt:0.12.6'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -44,6 +43,16 @@ dependencies {
 	// AWS S3
 	implementation platform('software.amazon.awssdk:bom:2.20.56')
 	implementation 'software.amazon.awssdk:s3'
+
+	// JSON
+	implementation 'com.google.code.gson:gson:2.10.1'
+	implementation 'net.minidev:json-smart:2.5.0'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testImplementation 'org.springframework.batch:spring-batch-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'io.rest-assured:rest-assured'
 
 	// AWS S3
 	implementation platform('software.amazon.awssdk:bom:2.20.56')

--- a/src/main/java/com/server/moabook/MoabookApplication.java
+++ b/src/main/java/com/server/moabook/MoabookApplication.java
@@ -2,7 +2,9 @@ package com.server.moabook;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class MoabookApplication {
 

--- a/src/main/java/com/server/moabook/config/MailConfig.java
+++ b/src/main/java/com/server/moabook/config/MailConfig.java
@@ -1,0 +1,16 @@
+package com.server.moabook.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        return new JavaMailSenderImpl();
+    }
+}

--- a/src/main/java/com/server/moabook/config/MailConfig.java
+++ b/src/main/java/com/server/moabook/config/MailConfig.java
@@ -1,16 +1,55 @@
 package com.server.moabook.config;
 
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
+import java.util.Properties;
+
 @Configuration
 public class MailConfig {
 
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.debug}")
+    private boolean debug;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttls;
+
     @Bean
     public JavaMailSender javaMailSender() {
-        return new JavaMailSenderImpl();
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties properties = mailSender.getJavaMailProperties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttls);
+        properties.put("mail.smtp.debug", debug);
+
+        mailSender.setJavaMailProperties(properties);
+        mailSender.setDefaultEncoding("UTF-8");
+
+        return mailSender;
     }
 }

--- a/src/main/java/com/server/moabook/config/SchedulerConfig.java
+++ b/src/main/java/com/server/moabook/config/SchedulerConfig.java
@@ -1,0 +1,21 @@
+package com.server.moabook.config;
+
+import com.server.moabook.mail.BatchService;
+import com.server.moabook.mail.MailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SchedulerConfig {
+
+    private final BatchService batchService;
+
+    @Scheduled(fixedDelay = 3600000, initialDelay = 5000)
+    public void run() {
+        batchService.sendMail();
+    }
+}

--- a/src/main/java/com/server/moabook/global/exception/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/server/moabook/global/exception/auth/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import com.server.moabook.global.exception.message.ErrorMessage;
 import com.server.moabook.global.jwt.JwtTokenProvider;
 import com.server.moabook.global.jwt.JwtValidationType;
 import com.server.moabook.global.jwt.UserAuthentication;
+import com.server.moabook.security.constant.Constant;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -16,11 +17,13 @@ import org.antlr.v4.runtime.misc.NotNull;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-
+import java.util.Arrays;
+import java.util.List;
 
 
 // 요청에서 Jwt를 검증하는 커스텀 필터 클래스
@@ -30,6 +33,16 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter  { // 요청이 주어졌을때 한번만 수행되는 필터를 상속받음
 
     private final JwtTokenProvider jwtTokenProvider;
+
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+
+        // 제외할 URL 리스트 중 하나라도 포함되면 필터 실행 안 함
+        return Arrays.stream(Constant.AUTH_WHITE_LIST)
+                .anyMatch(pattern -> new AntPathMatcher().match(pattern, path));
+    }
 
     @Override
     protected void doFilterInternal(@NotNull HttpServletRequest request,

--- a/src/main/java/com/server/moabook/global/exception/auth/SecurityConfig.java
+++ b/src/main/java/com/server/moabook/global/exception/auth/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.server.moabook.global.exception.auth;
 
+import com.server.moabook.security.constant.Constant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,17 +21,6 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
-    private final RequestHeaderLoggingFilter requestHeaderLoggingFilter;
-
-    private static final String[] AUTH_WHITE_LIST = {
-            "/oauth/**",
-            "/api/health",
-            "/api/callback",
-            "/swagger-ui/**",
-            "/v3/api-docs/**",
-            "/api/login/kakao",
-            "/ws/chat/**"
-    };
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -39,14 +29,17 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .requestCache(RequestCacheConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
+
                 .exceptionHandling(exception -> {
                     exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
                     exception.accessDeniedHandler(customAccessDeniedHandler);
                 })
+
                 .authorizeHttpRequests(auth -> {
-                    auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
-                    auth.anyRequest().permitAll();
+                    auth.requestMatchers(Constant.AUTH_WHITE_LIST).permitAll();
+                    auth.anyRequest().authenticated();
                 })
+
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/server/moabook/global/exception/dto/oauth/KakaoUserInfoRequestDto.java
+++ b/src/main/java/com/server/moabook/global/exception/dto/oauth/KakaoUserInfoRequestDto.java
@@ -1,12 +1,6 @@
 package com.server.moabook.global.exception.dto.oauth;
 
-import lombok.Builder;
-
-@Builder
 public record KakaoUserInfoRequestDto(
-        Long id,
-        String name,
-        String email,
-        String profile_image_url
+        String accessToken
 ) {
 }

--- a/src/main/java/com/server/moabook/global/exception/message/ErrorMessage.java
+++ b/src/main/java/com/server/moabook/global/exception/message/ErrorMessage.java
@@ -13,7 +13,8 @@ public enum ErrorMessage {
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 그룹을 찾을 수 없습니다."),
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 책을 찾을 수 없습니다."),
     PAGE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 책을 찾을 수 없습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다."),
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST.value(), "이메일 형식이 올바르지 않습니다."),;
     private final int code;
     private final String message;
 }

--- a/src/main/java/com/server/moabook/global/exception/message/SuccessMessage.java
+++ b/src/main/java/com/server/moabook/global/exception/message/SuccessMessage.java
@@ -23,7 +23,8 @@ public enum SuccessMessage {
     CREATE_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 생성을 성공하였습니다."),
     SAVE_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 저장을 성공하였습니다."),
     SELECT_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 조회를 성공하였습니다."),
-    DELETE_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 삭제를 성공하였습니다.");
+    DELETE_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 삭제를 성공하였습니다."),
+    UPDATE_RECEIVED_EMAIL_SUCCESS(HttpStatus.OK.value(), "이메일 수신 동의 여부가 반영되었습니다."),;
 
     private final int code;
     private final String message;

--- a/src/main/java/com/server/moabook/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/server/moabook/global/jwt/JwtTokenProvider.java
@@ -1,31 +1,49 @@
 package com.server.moabook.global.jwt;
 
+import com.server.moabook.security.dto.response.JwtTokenDto;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
 
 @Component // TokenProvider 클래스를 빈으로 등록
 @RequiredArgsConstructor
-public class JwtTokenProvider {
+public class JwtTokenProvider implements InitializingBean {
 
     private static final String USER_ID = "id";
 
-    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14; // 토큰 만료시간 설정
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 3; // 토큰 만료시간 3일로 설정
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14; // 토큰 만료시간 14일로 설정
+    private static final Logger log = LoggerFactory.getLogger(JwtTokenProvider.class);
 
     @Value("${spring.jwt.secret}") // application.yml 파일에 설정한 암호화 키를 가져옴
     private String JWT_SECRET;
 
+    private Key key;
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] keyBytes = Decoders.BASE64.decode(JWT_SECRET);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
 
     // Authentication 객체로 AccessToken 발행
-    public String issueAccessToken(final Authentication authentication) { // Authentication 객체 : 인증 주체(로그인하는 사용자)를 설명하기 위한 Spring Security의 인터페이스
-        return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+    public String issueAccessToken(Long id) { // Authentication 객체 : 인증 주체(로그인하는 사용자)를 설명하기 위한 Spring Security의 인터페이스
+        return generateToken(id, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+    public String issueRefreshToken(Long id) {
+        return generateToken(id, REFRESH_TOKEN_EXPIRATION_TIME);
     }
 
     /*
@@ -33,20 +51,26 @@ public class JwtTokenProvider {
     JWT에는 발행 시간, 만료 시간, 사용자 ID 등의 정보가 포함
     반환된 JWT는 응답으로 클라이언트에게 전달되거나, 클라이언트가 인증이 필요한 요청을 할 때 사용
     */
-    public String generateToken(Authentication authentication, Long tokenExpirationTime) {
-        final Date now = new Date();
-        final Claims claims = (Claims) Jwts.claims()
-                                  .setIssuedAt(now)
-                                  .setExpiration(new Date(now.getTime() + tokenExpirationTime)); // 만료 시간 설정
+    public String generateToken(Long id, Long tokenExpirationTime) {
 
-        claims.put(USER_ID, authentication.getPrincipal());
+        Claims claims = Jwts.claims();
+        Date now = new Date();
+
+        claims.put(USER_ID, id);
 
         return Jwts.builder()
                    .setHeaderParam(Header.TYPE, Header.JWT_TYPE)  // Header 설정
                    .setClaims(claims)  // Claim 설정
+                    .setIssuedAt(now)  // 토큰 발행 시간 설정
+                    .setExpiration(new Date(now.getTime() + tokenExpirationTime))  // 토큰 만료 시간 설정
                    .signWith(getSigningKey())  // 서명(Signature) 설정
                    .setIssuer("Codeable")
                    .compact();  // 최종적으로 JWT 토큰을 생성
+    }
+
+    // JwtTokenDto에 맞게 발생
+    public JwtTokenDto generateToken(Long id){
+        return new JwtTokenDto(issueAccessToken(id), issueRefreshToken(id));
     }
 
     private SecretKey getSigningKey() {
@@ -71,11 +95,8 @@ public class JwtTokenProvider {
     }
 
     private Claims getBody(final String token) {
-        return Jwts.parser()
-                   .setSigningKey(getSigningKey())
-                   .build()
-                   .parseClaimsJws(token)
-                   .getBody();
+        final JwtParser jwtParser = Jwts.parserBuilder().setSigningKey(key).build();
+        return jwtParser.parseClaimsJws(token).getBody();
     }
 
     // Token의 Claim에서 userId 값을 추출

--- a/src/main/java/com/server/moabook/mail/BatchService.java
+++ b/src/main/java/com/server/moabook/mail/BatchService.java
@@ -1,0 +1,28 @@
+package com.server.moabook.mail;
+
+import com.server.moabook.oauth2.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BatchService {
+
+    private final UserRepository userRepository;
+    private final MailService mailService;
+
+    public void sendMail() {
+
+        LocalDateTime oneMonthAgoDateTime = LocalDateTime.now().minusMonths(1);
+        String[] userEmailList = userRepository.findAllByExpiredUsersEmail(oneMonthAgoDateTime).toArray(new String[0]);
+
+        mailService.sendSimpleMailMessage(userEmailList);
+    }
+}

--- a/src/main/java/com/server/moabook/mail/BatchService.java
+++ b/src/main/java/com/server/moabook/mail/BatchService.java
@@ -1,5 +1,6 @@
 package com.server.moabook.mail;
 
+import com.server.moabook.oauth2.entity.SocialUserEntity;
 import com.server.moabook.oauth2.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,10 @@ public class BatchService {
 
         LocalDateTime oneMonthAgoDateTime = LocalDateTime.now().minusMonths(1);
         String[] userEmailList = userRepository.findAllByExpiredUsersEmail(oneMonthAgoDateTime).toArray(new String[0]);
-
+        //이메일을 발송했다면 해당 사용자들의 sended_email을 true로 변경
+        for (String email : userEmailList) {
+            userRepository.findByEmail(email).ifPresent(SocialUserEntity::updateSendedEmailTrue);
+        }
         mailService.sendSimpleMailMessage(userEmailList);
     }
 }

--- a/src/main/java/com/server/moabook/mail/BatchService.java
+++ b/src/main/java/com/server/moabook/mail/BatchService.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/com/server/moabook/mail/MailService.java
+++ b/src/main/java/com/server/moabook/mail/MailService.java
@@ -1,0 +1,90 @@
+package com.server.moabook.mail;
+
+import com.server.moabook.oauth2.repository.UserRepository;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendSimpleMailMessage(String[] userEmails) {
+
+        SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+
+        try {
+            // 메일을 받을 수신자 설정
+            simpleMailMessage.setTo(userEmails);
+
+            // 메일의 제목 설정
+            simpleMailMessage.setSubject("[MoABook] 모아북에서 내가 저장한 내용을 정리하세요!");
+
+            // 메일의 내용 설정
+            simpleMailMessage.setText("모아북을 사용하신 지 벌써 한 달이 지났어요! 내가 저장한 내용을 정리하고, 새로운 계획을 세워보세요!");
+
+            javaMailSender.send(simpleMailMessage);
+
+            log.info("메일 발송 성공!");
+        } catch (Exception e) {
+            log.info("메일 발송 실패!");
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public void sendMimeMessage(String[] userEmails) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        try{
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+
+            // 메일을 받을 수신자 설정
+            mimeMessageHelper.setTo(userEmails);
+            // 메일의 제목 설정
+            mimeMessageHelper.setSubject("[MoABook] 모아북에서 내가 저장한 내용을 정리하세요!");
+
+            // html 문법 적용한 메일의 내용
+            String content = """
+                    <!DOCTYPE html>
+                    <html xmlns:th="http://www.thymeleaf.org">
+                                        
+                    <body>
+                    <div style="margin:100px;">
+                        <h1> 테스트 메일 </h1>
+                        <br>
+                                        
+                                        
+                        <div align="center" style="border:1px solid black;">
+                            <h3> 테스트 메일 내용 </h3>
+                        </div>
+                        <br/>
+                    </div>
+                                        
+                    </body>
+                    </html>
+                    """;
+
+            // 메일의 내용 설정
+            mimeMessageHelper.setText(content, true);
+
+            javaMailSender.send(mimeMessage);
+
+            log.info("메일 발송 성공!");
+        } catch (Exception e) {
+            log.info("메일 발송 실패!");
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/server/moabook/mail/MailService.java
+++ b/src/main/java/com/server/moabook/mail/MailService.java
@@ -5,6 +5,7 @@ import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -28,6 +29,11 @@ public class MailService {
             // 메일을 받을 수신자 설정
             simpleMailMessage.setTo(userEmails);
 
+            if (userEmails.length == 0) {
+                log.info("메일을 발송할 대상이 없습니다.");
+                return;
+            }
+
             // 메일의 제목 설정
             simpleMailMessage.setSubject("[MoABook] 모아북에서 내가 저장한 내용을 정리하세요!");
 
@@ -39,7 +45,7 @@ public class MailService {
             log.info("메일 발송 성공!");
         } catch (Exception e) {
             log.info("메일 발송 실패!");
-            throw new RuntimeException(e);
+            throw new MailSendException("메일 발송 실패!");
         }
 
     }

--- a/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -29,7 +30,12 @@ public class SocialUserEntity {
 
     private String profile_image_url;
 
+    private LocalDateTime updated_at;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Group> groups;
 
+    public void updateUserUpdateTime(){
+        this.updated_at = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
@@ -54,4 +54,8 @@ public class SocialUserEntity {
     public void updateSendedEmailFalse(){
         this.sended_email = false;
     }
+
+    public void updateEmail(String email){
+        this.email = email;
+    }
 }

--- a/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
@@ -43,8 +43,8 @@ public class SocialUserEntity {
         this.updated_at = LocalDateTime.now();
     }
 
-    public void updateReceivedEmail(){
-        this.received_email = true;
+    public void updateReceivedEmail(boolean check){
+        this.received_email = check;
     }
 
     public void updateSendedEmailTrue(){

--- a/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
@@ -32,10 +32,26 @@ public class SocialUserEntity {
 
     private LocalDateTime updated_at;
 
+    private Boolean received_email;
+
+    private Boolean sended_email;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Group> groups;
 
     public void updateUserUpdateTime(){
         this.updated_at = LocalDateTime.now();
+    }
+
+    public void updateReceivedEmail(){
+        this.received_email = true;
+    }
+
+    public void updateSendedEmailTrue(){
+        this.sended_email = true;
+    }
+
+    public void updateSendedEmailFalse(){
+        this.sended_email = false;
     }
 }

--- a/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
@@ -21,20 +21,29 @@ public class SocialUserEntity {
     @Column(name = "userId")
     private Long id;
 
+    @Column(name = "username")
     private String username;
 
     @Column(unique = true)
     private String email;
 
+    @Column(name = "role")
     private String role;
 
+    @Column(name = "profile_image_url")
     private String profile_image_url;
 
+    @Column(name = "updated_at")
     private LocalDateTime updated_at;
 
-    private Boolean received_email;
+    @Column(name = "received_email")
+    private boolean received_email;
 
-    private Boolean sended_email;
+    @Column(name = "sended_email")
+    private boolean sended_email;
+
+    @Column(name = "refresh_token")
+    private String refreshToken;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Group> groups;
@@ -57,5 +66,9 @@ public class SocialUserEntity {
 
     public void updateEmail(String email){
         this.email = email;
+    }
+
+    public void updateRefreshToken(String refreshToken){
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
+++ b/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
@@ -2,6 +2,16 @@ package com.server.moabook.oauth2.repository;
 
 import com.server.moabook.oauth2.entity.SocialUserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<SocialUserEntity, Long> {
+    SocialUserEntity findByUsername(String username);
+    Optional<SocialUserEntity> findByEmail(String email);
+
+    @Query("SELECT u.email FROM SocialUserEntity u WHERE u.updated_at < :minusOneMonthAgoDateTime")
+    List<String> findAllByExpiredUsersEmail(LocalDateTime minusOneMonthAgoDateTime);
 }

--- a/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
+++ b/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
@@ -12,6 +12,6 @@ public interface UserRepository extends JpaRepository<SocialUserEntity, Long> {
     SocialUserEntity findByUsername(String username);
     Optional<SocialUserEntity> findByEmail(String email);
 
-    @Query("SELECT u.email FROM SocialUserEntity u WHERE u.updated_at < :minusOneMonthAgoDateTime")
+    @Query("SELECT u.email FROM SocialUserEntity u WHERE u.updated_at < :minusOneMonthAgoDateTime AND u.received_email = true AND u.sended_email = false")
     List<String> findAllByExpiredUsersEmail(LocalDateTime minusOneMonthAgoDateTime);
 }

--- a/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
+++ b/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
@@ -14,4 +14,7 @@ public interface UserRepository extends JpaRepository<SocialUserEntity, Long> {
 
     @Query("SELECT u.email FROM SocialUserEntity u WHERE u.updated_at < :minusOneMonthAgoDateTime AND u.received_email = true AND u.sended_email = false")
     List<String> findAllByExpiredUsersEmail(LocalDateTime minusOneMonthAgoDateTime);
+
+    @Query("SELECT u FROM SocialUserEntity u WHERE u.id = :id")
+    SocialUserEntity findByKakaoUserId(Long id);
 }

--- a/src/main/java/com/server/moabook/security/constant/Constant.java
+++ b/src/main/java/com/server/moabook/security/constant/Constant.java
@@ -1,0 +1,13 @@
+package com.server.moabook.security.constant;
+
+public class Constant {
+
+    public static final String[] AUTH_WHITE_LIST = {
+            "/oauth/**",
+            "/api/health",
+            "/api/callback",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/api/login/kakao",
+    };
+}

--- a/src/main/java/com/server/moabook/security/controller/GeneralMemberController.java
+++ b/src/main/java/com/server/moabook/security/controller/GeneralMemberController.java
@@ -5,14 +5,12 @@ import com.server.moabook.global.exception.dto.oauth.KakaoUserInfoRequestDto;
 import com.server.moabook.global.exception.message.SuccessMessage;
 import com.server.moabook.security.dto.response.SuccessLoginResponseDto;
 import com.server.moabook.security.service.GeneralMemberService;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -21,17 +19,27 @@ import org.springframework.web.bind.annotation.RestController;
 public class GeneralMemberController {
 
     private final GeneralMemberService generalMemberService;
+
     //카카오 로그인 메소드
     @PostMapping("/login/kakao")
-    public ResponseEntity<SuccessStatusResponse<SuccessLoginResponseDto>> login(@RequestBody KakaoUserInfoRequestDto userInfo) {
-        // 3. 사용자 로그인 또는 회원가입 처리
-        SuccessLoginResponseDto successLoginResponseDto = generalMemberService.findUserWithReact(userInfo);
+    public ResponseEntity<SuccessStatusResponse<SuccessLoginResponseDto>> login(
+            @RequestBody @NotNull KakaoUserInfoRequestDto userInfo
+    ) {
+        SuccessLoginResponseDto successLoginResponseDto = generalMemberService.kakaoAuthSocialLogin(userInfo);
 
-        // 5. 메인 페이지로 리다이렉트
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessStatusResponse.of(
                         SuccessMessage.SIGNIN_SUCCESS, successLoginResponseDto
                 )
+        );
+    }
+
+    // 액세스 토큰 재발급 및 리프레시 토큰 업데이트 API
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(
+            @NotNull @RequestHeader("Authorization") String refreshToken) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                generalMemberService.refresh(refreshToken)
         );
     }
 }

--- a/src/main/java/com/server/moabook/security/dto/response/JwtTokenDto.java
+++ b/src/main/java/com/server/moabook/security/dto/response/JwtTokenDto.java
@@ -1,0 +1,12 @@
+package com.server.moabook.security.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+
+public record JwtTokenDto(
+
+        @NotNull(message = "AccessToken은 null이 될 수 없습니다.")
+        String accessToken,
+        @NotNull(message = "RefreshToken은 null이 될 수 없습니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/server/moabook/security/dto/response/KakaoUserInfoDto.java
+++ b/src/main/java/com/server/moabook/security/dto/response/KakaoUserInfoDto.java
@@ -1,0 +1,8 @@
+package com.server.moabook.security.dto.response;
+
+public record KakaoUserInfoDto(Long id, String email, String nickname, String profileImageUrl) {
+
+    public static KakaoUserInfoDto of(Long id, String email, String nickname, String profileImageUrl) {
+        return new KakaoUserInfoDto(id, email, nickname, profileImageUrl);
+    }
+}

--- a/src/main/java/com/server/moabook/security/dto/response/SuccessLoginResponseDto.java
+++ b/src/main/java/com/server/moabook/security/dto/response/SuccessLoginResponseDto.java
@@ -8,6 +8,7 @@ public record SuccessLoginResponseDto (
         String name,
         String email,
         String profile_image_url,
-        String jwtToken
+        JwtTokenDto jwtToken,
+        boolean received_email
 ){
 }

--- a/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
+++ b/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
@@ -1,14 +1,18 @@
 package com.server.moabook.security.service;
 
+import com.server.moabook.global.exception.BusinessException;
+import com.server.moabook.global.exception.NotFoundException;
 import com.server.moabook.global.exception.dto.oauth.KakaoUserInfoRequestDto;
+import com.server.moabook.global.exception.message.ErrorMessage;
 import com.server.moabook.global.jwt.JwtTokenProvider;
-import com.server.moabook.global.jwt.UserAuthentication;
 import com.server.moabook.oauth2.entity.SocialUserEntity;
 import com.server.moabook.oauth2.repository.UserRepository;
+import com.server.moabook.security.dto.response.JwtTokenDto;
+import com.server.moabook.security.dto.response.KakaoUserInfoDto;
 import com.server.moabook.security.dto.response.SuccessLoginResponseDto;
+import com.server.moabook.utils.OAuth2Util;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,48 +24,97 @@ import java.time.LocalDateTime;
 @Transactional
 public class GeneralMemberService {
 
-    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
-    private String clientId;
-
-    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
-    private String redirectUri;
-
-    private static final String KAUTH_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
-    private static final String KAPI_USER_URL = "https://kapi.kakao.com/v2/user/me";
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final OAuth2Util oAuth2Util;
 
-    // 사용자 정보 가져오기 - 이메일, 닉네임, 프로필 사진
-    public SuccessLoginResponseDto findUserWithReact(KakaoUserInfoRequestDto userInfo) {
+    // 카카오 소셜 로그인
+    public SuccessLoginResponseDto kakaoAuthSocialLogin(KakaoUserInfoRequestDto kakaoUserInfoRequestDto) {
+        String accessToken = refineToken(kakaoUserInfoRequestDto.accessToken());
 
-        SocialUserEntity socialUserEntity = userRepository.findById(userInfo.id())
-                .orElseGet(() -> {
-                    SocialUserEntity newGeneralMember = SocialUserEntity.builder()
-                            .id(userInfo.id())
-                            .username(userInfo.name())
-                            .email(userInfo.email())
-                            .role("ROLE_USER")
-                            .profile_image_url(userInfo.profile_image_url())
-                            .build();
-                    return userRepository.save(newGeneralMember);
-                });
+        KakaoUserInfoDto kakaoUserInfoDto = oAuth2Util.getKakaoUserInfo(accessToken);;
+
+        return processKakaoUserLogin(kakaoUserInfoDto);
+    }
+
+    private String refineToken(String accessToken) {
+        return accessToken.startsWith("Bearer")
+                ? accessToken.substring(6)
+                : accessToken;
+    }
+
+    // 카카오 로그인 프로세스
+    private SuccessLoginResponseDto processKakaoUserLogin(KakaoUserInfoDto kakaoUserInfo) {
+        SocialUserEntity user = userRepository.findByKakaoUserId(kakaoUserInfo.id());
+
+        if (user == null) {
+            // 새로운 사용자 등록
+            SocialUserEntity newUser = registerNewKakaoUser(kakaoUserInfo);
+            return handleExistingUserLogin(newUser);
+        }
+        return handleExistingUserLogin(user);
+    }
+
+    private SocialUserEntity registerNewKakaoUser(KakaoUserInfoDto kakaoUserInfo) {
+        SocialUserEntity newUser =
+                new SocialUserEntity().builder()
+                        .id(kakaoUserInfo.id())
+                        .email(kakaoUserInfo.email())
+                        .username(kakaoUserInfo.nickname())
+                        .profile_image_url(kakaoUserInfo.profileImageUrl())
+                        .role("USER")
+                        .updated_at(LocalDateTime.now())
+                        .received_email(false)
+                        .sended_email(false)
+                        .build();
+        return userRepository.save(newUser);
+    }
+
+    // 기존 사용자 로그인 처리
+    private SuccessLoginResponseDto handleExistingUserLogin(SocialUserEntity user) {
+
+        // 토큰 생성 후 업데이트
+        JwtTokenDto jwtTokenDto = jwtTokenProvider.generateToken(user.getId());
+        user.updateRefreshToken(jwtTokenDto.refreshToken());
 
         //로그인 시 사용자 사용시간 업데이트
-        socialUserEntity.updateUserUpdateTime();
+        user.updateUserUpdateTime();
         //로그인 시 사용자가 나중에 다시 접속이 오래 이어지지 않았을 때 다시 이메일을 받을 수 있게 설정
-        socialUserEntity.updateSendedEmailFalse();
+        user.updateSendedEmailFalse();
+        // 로그인 후 필요한 데이터를 생성하고 반환
+        return SuccessLoginResponseDto.builder()
+                .id(user.getId())
+                .name(user.getUsername())
+                .email(user.getEmail())
+                .profile_image_url(user.getProfile_image_url())
+                .jwtToken(jwtTokenDto)
+                .received_email(user.isReceived_email())
+                .build();
+    }
 
-        // JWT 토큰 발급
-        String jwtToken = jwtTokenProvider.issueAccessToken(
-                UserAuthentication.createUserAuthentication(socialUserEntity.getId())
-        );
+    public SuccessLoginResponseDto refresh(String token) {
+        String refreshToken = this.refineToken(token);
+
+        Long userId = jwtTokenProvider.getUserFromJwt(refreshToken);
+
+        SocialUserEntity user = userRepository.findById(userId)
+                .orElseThrow(()-> new NotFoundException(ErrorMessage.USER_NOT_FOUND));
+
+        if (!user.getRefreshToken().equals(refreshToken)) {
+            throw new BusinessException(ErrorMessage.INVALID_JWT_TOKEN);
+        }
+
+        JwtTokenDto jwtTokenDto = jwtTokenProvider.generateToken(userId);
+        // 액세스 토큰을 다시 발급받을 때 refreshToken도 같이 업데이트 하여 장기간 접속하지 않는 한 로그인 유지
+        user.updateRefreshToken(jwtTokenDto.refreshToken());
 
         return SuccessLoginResponseDto.builder()
-                .id(socialUserEntity.getId())
-                .name(socialUserEntity.getUsername())
-                .email(socialUserEntity.getEmail())
-                .profile_image_url(socialUserEntity.getProfile_image_url())
-                .jwtToken(jwtToken)
+                .id(user.getId())
+                .name(user.getUsername())
+                .email(user.getEmail())
+                .profile_image_url(user.getProfile_image_url())
+                .jwtToken(jwtTokenDto)
+                .received_email(user.isReceived_email())
                 .build();
     }
 

--- a/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
+++ b/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
@@ -46,7 +46,10 @@ public class GeneralMemberService {
                     return userRepository.save(newGeneralMember);
                 });
 
+        //로그인 시 사용자 사용시간 업데이트
         socialUserEntity.updateUserUpdateTime();
+        //로그인 시 사용자가 나중에 다시 접속이 오래 이어지지 않았을 때 다시 이메일을 받을 수 있게 설정
+        socialUserEntity.updateSendedEmailFalse();
 
         // JWT 토큰 발급
         String jwtToken = jwtTokenProvider.issueAccessToken(

--- a/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
+++ b/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -29,7 +31,7 @@ public class GeneralMemberService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
-    // 사용자 정보 가져오기 - 이메일, 닉네임, 프로필 사진, 여행 등급
+    // 사용자 정보 가져오기 - 이메일, 닉네임, 프로필 사진
     public SuccessLoginResponseDto findUserWithReact(KakaoUserInfoRequestDto userInfo) {
 
         SocialUserEntity socialUserEntity = userRepository.findById(userInfo.id())
@@ -43,6 +45,8 @@ public class GeneralMemberService {
                             .build();
                     return userRepository.save(newGeneralMember);
                 });
+
+        socialUserEntity.updateUserUpdateTime();
 
         // JWT 토큰 발급
         String jwtToken = jwtTokenProvider.issueAccessToken(

--- a/src/main/java/com/server/moabook/user/controller/UserController.java
+++ b/src/main/java/com/server/moabook/user/controller/UserController.java
@@ -61,10 +61,12 @@ public class UserController {
     @PatchMapping
     public ResponseEntity<SuccessStatusResponse<Void>> updateReceivedEmail(
             @RequestHeader("Authorization") String token,
-            @RequestParam("received_email") boolean checkReceivedEmail) {
+            @RequestParam(value = "user_email", required = false) String email,
+            @RequestParam("is_received_email") boolean checkReceivedEmail) {
 
         Long userId = jwtTokenProvider.getUserFromJwt(token);
-        userService.updateReceivedEmail(userId, checkReceivedEmail);
+
+        userService.updateReceivedEmail(userId, email, checkReceivedEmail);
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessStatusResponse.of(

--- a/src/main/java/com/server/moabook/user/controller/UserController.java
+++ b/src/main/java/com/server/moabook/user/controller/UserController.java
@@ -58,4 +58,19 @@ public class UserController {
         );
     }
 
+    @PatchMapping
+    public ResponseEntity<SuccessStatusResponse<Void>> updateReceivedEmail(
+            @RequestHeader("Authorization") String token,
+            @RequestParam("received_email") boolean checkReceivedEmail) {
+
+        Long userId = jwtTokenProvider.getUserFromJwt(token);
+        userService.updateReceivedEmail(userId, checkReceivedEmail);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessStatusResponse.of(
+                        SuccessMessage.UPDATE_RECEIVED_EMAIL_SUCCESS, null
+                )
+        );
+    }
+
 }

--- a/src/main/java/com/server/moabook/user/service/UserService.java
+++ b/src/main/java/com/server/moabook/user/service/UserService.java
@@ -35,4 +35,10 @@ public class UserService {
         groupRepository.deleteAll(socialUserEntity.getGroups());
     }
 
+    public void updateReceivedEmail(Long userId, boolean check) {
+        SocialUserEntity socialUserEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException(String.valueOf(ErrorMessage.USER_NOT_FOUND)));
+        socialUserEntity.updateReceivedEmail(check);
+    }
+
 }

--- a/src/main/java/com/server/moabook/user/service/UserService.java
+++ b/src/main/java/com/server/moabook/user/service/UserService.java
@@ -9,6 +9,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.regex.Pattern;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -16,6 +18,10 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final GroupRepository groupRepository;
+
+    private static final String EMAIL_REGEX = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX);
+
 
     public SelectUserResponseDto select(Long userId) {
         SocialUserEntity socialUserEntity = userRepository.findById(userId)
@@ -35,10 +41,20 @@ public class UserService {
         groupRepository.deleteAll(socialUserEntity.getGroups());
     }
 
-    public void updateReceivedEmail(Long userId, boolean check) {
+    public void updateReceivedEmail(Long userId, String email, boolean check) {
         SocialUserEntity socialUserEntity = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalStateException(String.valueOf(ErrorMessage.USER_NOT_FOUND)));
         socialUserEntity.updateReceivedEmail(check);
+        if(isValidEmail(email)) {
+            socialUserEntity.updateEmail(email);
+        }
+    }
+
+    public static boolean isValidEmail(String email) {
+        if (email == null || email.trim().isEmpty()) {
+            return false; // null 또는 빈 값 체크
+        }
+        return EMAIL_PATTERN.matcher(email).matches();
     }
 
 }

--- a/src/main/java/com/server/moabook/utils/OAuth2Util.java
+++ b/src/main/java/com/server/moabook/utils/OAuth2Util.java
@@ -1,0 +1,53 @@
+package com.server.moabook.utils;
+
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.server.moabook.security.dto.response.KakaoUserInfoDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@Slf4j
+public class OAuth2Util {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    private static final String KAPI_USER_URL = "https://kapi.kakao.com/v2/user/me";
+
+    public KakaoUserInfoDto getKakaoUserInfo(String accessToken) {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        httpHeaders.add("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<?> kakaoProfileRequest = new HttpEntity<>(httpHeaders);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange(
+                        KAPI_USER_URL,
+                        HttpMethod.POST,
+                        kakaoProfileRequest,
+                        String.class);
+
+        if (response.getBody() == null) {
+            throw new RuntimeException("Kakao API 요청에 실패했습니다.");
+        }
+
+        JsonElement element = JsonParser.parseString(response.getBody());
+
+        return KakaoUserInfoDto.of(
+                element.getAsJsonObject().get("id").getAsLong(),
+                element.getAsJsonObject().getAsJsonObject("kakao_account")
+                        .get("email").getAsString(),
+                element.getAsJsonObject().getAsJsonObject("kakao_account")
+                        .getAsJsonObject("profile").get("nickname").getAsString(),
+                element.getAsJsonObject().getAsJsonObject("kakao_account")
+                        .getAsJsonObject("profile").get("profile_image_url").getAsString());
+    }
+}


### PR DESCRIPTION
# 로그인 로직 수정
카카오에서 기존 방식과 달리 accessToken만 받아도 로그인이 가능하도록 설정했습니다.

또한, 리프레시 토큰도 클라이언트에게 제공하고, 리프레시 토큰을 재발급 받을 수 있는 API도 함께 제공합니다. 