### PR TITLE
[FIX] 로그인 로직 오류 수정 

### DIFF
--- a/.github/workflows/main_CICD.yml
+++ b/.github/workflows/main_CICD.yml
@@ -55,4 +55,5 @@ jobs:
 
             sudo docker run -d --name moabook-server \
             -p 8080:8080 \
+            --network moabook_network \
             5hseok/moabook-server:0.0.1

--- a/src/main/java/com/server/moabook/global/exception/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/server/moabook/global/exception/auth/JwtAuthenticationFilter.java
@@ -50,10 +50,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter  { // 요청�
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
         try {
             final String token = getJwtFromRequest(request);
-            log.info("token:" + token);
             if (jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) { // 추출한 토큰의 정보가 VALID_JWT일 경우 사용자 정보 추출
+                log.info("token:" + token);
                 Long memberId = jwtTokenProvider.getUserFromJwt(token);
 
+                log.info("memberId:" + memberId);
                 UserAuthentication authentication = UserAuthentication.createUserAuthentication(memberId);
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 // 추출한 UserId 기반 authentication 객체 생성

--- a/src/main/java/com/server/moabook/global/exception/message/SuccessMessage.java
+++ b/src/main/java/com/server/moabook/global/exception/message/SuccessMessage.java
@@ -24,7 +24,8 @@ public enum SuccessMessage {
     SAVE_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 저장을 성공하였습니다."),
     SELECT_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 조회를 성공하였습니다."),
     DELETE_PAGE_SUCCESS(HttpStatus.OK.value(),"페이지 삭제를 성공하였습니다."),
-    UPDATE_RECEIVED_EMAIL_SUCCESS(HttpStatus.OK.value(), "이메일 수신 동의 여부가 반영되었습니다."),;
+    UPDATE_RECEIVED_EMAIL_SUCCESS(HttpStatus.OK.value(), "이메일 수신 동의 여부가 반영되었습니다."),
+    HEALTH_CHECK_SUCCESS(HttpStatus.OK.value(), "서버 정상 작동 중입니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/server/moabook/global/health/HealthCheckController.java
+++ b/src/main/java/com/server/moabook/global/health/HealthCheckController.java
@@ -1,0 +1,47 @@
+package com.server.moabook.global.health;
+
+import com.server.moabook.global.exception.dto.SuccessStatusResponse;
+import com.server.moabook.global.exception.message.SuccessMessage;
+import com.server.moabook.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/health")
+public class HealthCheckController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping
+    public ResponseEntity<SuccessStatusResponse<Void>> healthCheck() {
+        log.info("Health Check");
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessStatusResponse.of(
+                        SuccessMessage.HEALTH_CHECK_SUCCESS, null
+                )
+        );
+    }
+
+    @GetMapping("/token")
+    public ResponseEntity<SuccessStatusResponse<Long>> tokenCheck(
+            @RequestHeader("Authorization") String token
+    ) {
+        log.info(jwtTokenProvider.validateToken(token).toString());
+        Long userId = jwtTokenProvider.getUserFromJwt(token);
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessStatusResponse.of(
+                        SuccessMessage.SIGNIN_SUCCESS, userId
+                )
+        );
+    }
+
+}

--- a/src/main/java/com/server/moabook/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/server/moabook/global/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.server.moabook.global.jwt;
 
 import com.server.moabook.security.dto.response.JwtTokenDto;
+import com.server.moabook.security.service.GeneralMemberService;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -15,30 +16,20 @@ import javax.crypto.SecretKey;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
-
-@Component // TokenProvider 클래스를 빈으로 등록
+@Component
 @RequiredArgsConstructor
-public class JwtTokenProvider implements InitializingBean {
+public class JwtTokenProvider{
 
     private static final String USER_ID = "id";
 
-    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 3; // 토큰 만료시간 3일로 설정
-    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14; // 토큰 만료시간 14일로 설정
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 3;
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
     private static final Logger log = LoggerFactory.getLogger(JwtTokenProvider.class);
 
-    @Value("${spring.jwt.secret}") // application.yml 파일에 설정한 암호화 키를 가져옴
+    @Value("${spring.jwt.secret}")
     private String JWT_SECRET;
 
-    private Key key;
-
-    @Override
-    public void afterPropertiesSet() {
-        byte[] keyBytes = Decoders.BASE64.decode(JWT_SECRET);
-        this.key = Keys.hmacShaKeyFor(keyBytes);
-    }
-
-    // Authentication 객체로 AccessToken 발행
-    public String issueAccessToken(Long id) { // Authentication 객체 : 인증 주체(로그인하는 사용자)를 설명하기 위한 Spring Security의 인터페이스
+    public String issueAccessToken(Long id) {
         return generateToken(id, ACCESS_TOKEN_EXPIRATION_TIME);
     }
 
@@ -46,39 +37,26 @@ public class JwtTokenProvider implements InitializingBean {
         return generateToken(id, REFRESH_TOKEN_EXPIRATION_TIME);
     }
 
-    /*
-    사용자 정보를 포함한 JWT를 생성하여 반환
-    JWT에는 발행 시간, 만료 시간, 사용자 ID 등의 정보가 포함
-    반환된 JWT는 응답으로 클라이언트에게 전달되거나, 클라이언트가 인증이 필요한 요청을 할 때 사용
-    */
     public String generateToken(Long id, Long tokenExpirationTime) {
-
         Claims claims = Jwts.claims();
         Date now = new Date();
 
         claims.put(USER_ID, id);
 
         return Jwts.builder()
-                   .setHeaderParam(Header.TYPE, Header.JWT_TYPE)  // Header 설정
-                   .setClaims(claims)  // Claim 설정
-                    .setIssuedAt(now)  // 토큰 발행 시간 설정
-                    .setExpiration(new Date(now.getTime() + tokenExpirationTime))  // 토큰 만료 시간 설정
-                   .signWith(getSigningKey())  // 서명(Signature) 설정
-                   .setIssuer("Codeable")
-                   .compact();  // 최종적으로 JWT 토큰을 생성
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenExpirationTime))
+                .signWith(getSigningKey())
+                .setIssuer("Codeable")
+                .compact();
     }
 
-    // JwtTokenDto에 맞게 발생
-    public JwtTokenDto generateToken(Long id){
+    public JwtTokenDto generateToken(Long id) {
         return new JwtTokenDto(issueAccessToken(id), issueRefreshToken(id));
     }
 
-    private SecretKey getSigningKey() {
-        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes()); //SecretKey 통해 서명 생성
-        return Keys.hmacShaKeyFor(encodedKey.getBytes());   //일반적으로 HMAC (Hash-based Message Authentication Code) 알고리즘 사용 -> 암호화 키 생성
-    }
-
-    // Token에서 Claim을 추출하는 과정에서 에러가 발생하면 catch한후 validation 진행
     public JwtValidationType validateToken(String token) {
         try {
             final Claims claims = getBody(token);
@@ -94,12 +72,18 @@ public class JwtTokenProvider implements InitializingBean {
         }
     }
 
-    private Claims getBody(final String token) {
-        final JwtParser jwtParser = Jwts.parserBuilder().setSigningKey(key).build();
+    private SecretKey getSigningKey() {
+        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes()); //SecretKey 통해 서명 생성
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());   //일반적으로 HMAC (Hash-based Message Authentication Code) 알고리즘 사용 -> 암호화 키 생성
+    }
+
+    private Claims getBody(String token) {
+        final JwtParser jwtParser = Jwts.parserBuilder().setSigningKey(getSigningKey()).build();
+        token = GeneralMemberService.refineToken(token);
+        log.info(jwtParser.parseClaimsJws(token).getBody().toString());
         return jwtParser.parseClaimsJws(token).getBody();
     }
 
-    // Token의 Claim에서 userId 값을 추출
     public Long getUserFromJwt(String token) {
         Claims claims = getBody(token);
         return Long.valueOf(claims.get(USER_ID).toString());

--- a/src/main/java/com/server/moabook/mail/BatchService.java
+++ b/src/main/java/com/server/moabook/mail/BatchService.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -22,10 +23,14 @@ public class BatchService {
 
         LocalDateTime oneMonthAgoDateTime = LocalDateTime.now().minusMonths(1);
         String[] userEmailList = userRepository.findAllByExpiredUsersEmail(oneMonthAgoDateTime).toArray(new String[0]);
-        //이메일을 발송했다면 해당 사용자들의 sended_email을 true로 변경
-        for (String email : userEmailList) {
-            userRepository.findByEmail(email).ifPresent(SocialUserEntity::updateSendedEmailTrue);
+
+        if (userEmailList.length == 0) {
+            log.info("메일을 발송할 대상이 없습니다.");
+            return;
         }
+
+        //이메일을 발송했다면 해당 사용자들의 sended_email을 true로 변경
+        userRepository.updateSendedEmailByEmails(List.of(userEmailList));
         mailService.sendSimpleMailMessage(userEmailList);
     }
 }

--- a/src/main/java/com/server/moabook/mail/MailService.java
+++ b/src/main/java/com/server/moabook/mail/MailService.java
@@ -29,11 +29,6 @@ public class MailService {
             // 메일을 받을 수신자 설정
             simpleMailMessage.setTo(userEmails);
 
-            if (userEmails.length == 0) {
-                log.info("메일을 발송할 대상이 없습니다.");
-                return;
-            }
-
             // 메일의 제목 설정
             simpleMailMessage.setSubject("[MoABook] 모아북에서 내가 저장한 내용을 정리하세요!");
 

--- a/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/server/moabook/oauth2/entity/SocialUserEntity.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@DynamicUpdate
 @Table(name = "user")
 public class SocialUserEntity {
     @Id

--- a/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
+++ b/src/main/java/com/server/moabook/oauth2/repository/UserRepository.java
@@ -2,7 +2,9 @@ package com.server.moabook.oauth2.repository;
 
 import com.server.moabook.oauth2.entity.SocialUserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,4 +19,9 @@ public interface UserRepository extends JpaRepository<SocialUserEntity, Long> {
 
     @Query("SELECT u FROM SocialUserEntity u WHERE u.id = :id")
     SocialUserEntity findByKakaoUserId(Long id);
+
+
+    @Modifying
+    @Query("UPDATE SocialUserEntity u SET u.sended_email = true WHERE u.email IN :emails")
+    int updateSendedEmailByEmails(@Param("emails") List<String> emails);
 }

--- a/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
+++ b/src/main/java/com/server/moabook/security/service/GeneralMemberService.java
@@ -37,7 +37,7 @@ public class GeneralMemberService {
         return processKakaoUserLogin(kakaoUserInfoDto);
     }
 
-    private String refineToken(String accessToken) {
+    public static String refineToken(String accessToken) {
         return accessToken.startsWith("Bearer")
                 ? accessToken.substring(6)
                 : accessToken;


### PR DESCRIPTION
로그인 시 JWT 서명을 동시에 하는 문제가 있었어서 생긴 문제였습니다.

기존 방식처럼 사인하도록 동작했고, 이를 검증할 수 있는 테스트 API도 추가해뒀습니다.

/api/health로는 토큰 필요없이 서버 health check용, 
/api/health/token으로는 Authorization 헤더에 Bearer {tokenContent}로 토큰을 넣어 요청하면 사용자의 id가 출력되도록 하여 로그인이 가능한 지를 살펴보았습니다. 

추가로 MySQL도 RDS가 아니라 EC2 내부에서 그냥 돌려버리는 구조이기 때문에 MySQL과 Spring 컨테이너가 서로 연결되어 동작할 수 있게  network를 새로 정의하고 거기에 컨테이너를 추가하는 방식으로 수정했습니다.

